### PR TITLE
Allow spawning multiple prefabs

### DIFF
--- a/Assets/Flightmare/Scripts/MessageSpec.cs
+++ b/Assets/Flightmare/Scripts/MessageSpec.cs
@@ -36,6 +36,12 @@ namespace MessageSpec
 
     private Dictionary<string, ObjectState_t> objects;
 
+    // Tells if the given object exists inside the environment.
+    public bool contains(string ID)
+    {
+      return objects.ContainsKey(ID);
+    }
+
     // Advanced getters/setters
     // Get Wrapper object, defaulting to a passed in template if it does not exist.
     public ObjectState_t getWrapperObject(string ID, GameObject template)
@@ -164,7 +170,7 @@ namespace MessageSpec
   // =============================
   public class SettingsMessage_t
   {
-    // Startup parameters. 
+    // Startup parameters.
     // public bool sceneIsInternal { get; set; }
     public int scene_id { get; set; }
 
@@ -178,7 +184,7 @@ namespace MessageSpec
     // ==============================================================================
     public int numVehicles { get { return vehicles.Count(); } }
     public Vehicle_t mainVehicle { get; set; }
-    // we noly count the number of camera on the main vehicle. 
+    // we noly count the number of camera on the main vehicle.
     public int numCameras { get; set; }
     public Camera_t mainCamera { get; set; }
     // public List<Camera_t> cameras{ get; set; }
@@ -190,7 +196,7 @@ namespace MessageSpec
     public void InitParamsters()
     {
       // kind of ugly, the purpose is to handle
-      // the vehile that has no cameras. 
+      // the vehile that has no cameras.
       if (numVehicles > 0)
       {
         mainVehicle = vehicles[(int)(numVehicles / 2)];


### PR DESCRIPTION
This PR deals with uzh-rpg/flightmare#77. More specifically it slightly changes the `CameraController.cs` script so that any prefab in the `Templates` folder can be spawned. All trailing white spaces in the modified sources were also removed.

A demo in flightmare (showing that these changes do work) is being proposed in the sibling PR uzh-rpg/flightmare#125.

@yun-long and @slimeth there are still 2 improvements that I would like to introduce, but I prefer having your feedback first:

1. Currently, if you try to spawn a prefab not appearing in `Templates`, you will get a `rpg_gate` instead. I would prefer to create a new prefab, *e.g.*, a cube with "404 not found" written on it, and spawn that instead. I think that showing such kind of object makes it much clearer that an error occurred.
2. Currently, you can only add objects, but I have already worked on a variant of the scripts that also allows to remove them. Do you think such a feature is desirable? If so, I'll polish my solution and add it to this PR.

Cheers! 