### PR TITLE
include first row of static obstacles csv

### DIFF
--- a/Assets/Flightmare/Scripts/ConfigObjects.cs
+++ b/Assets/Flightmare/Scripts/ConfigObjects.cs
@@ -87,9 +87,9 @@ namespace RPGFlightmare
         }
 
         obj_id += 1;
-        if (obj_id <= 1) {
-          continue;
-        }
+        // if (obj_id <= 1) {
+        //   continue;
+        // }
 
         var data_values = data_string.Split(",");
 


### PR DESCRIPTION
The CSVs used in https://github.com/uzh-rpg/agile_flight do not have a header row, so it seems we should not skip the first line.

The current code results in 1 ghost obstacle in my experience.